### PR TITLE
add timeout for unresponsive feeds

### DIFF
--- a/rssplugin/cms_plugins.py
+++ b/rssplugin/cms_plugins.py
@@ -9,11 +9,9 @@ from django.core.cache import cache
 from django.utils.translation import ugettext as _
 import feedparser
 
-try:
-    from django.conf import settings
-    rss_render_template = settings.CMS_RSS_PLUGIN_TEMPLATE
-except:
-    rss_render_template = "rss/rss.html"
+from django.conf import settings
+rss_render_template = getattr(settings, 'CMS_RSS_PLUGIN_TEMPLATE', "rss/rss.html")
+feedparser_timeout = getattr(settings, 'CMS_RSS_PLUGIN_FEEDPARSER_TIMEOUT', 60)
 
 
 class PlanetPlugin(CMSPluginBase):
@@ -26,10 +24,7 @@ class PlanetPlugin(CMSPluginBase):
         feed = cache.get(instance.rss_url)
         if not feed:
             url = self._build_feed_url(context, instance.rss_url)
-            feed = feedparser.parse(url)
-            if 'bozo_exception' in feed:
-                logging.warning('Error parsing feed %s.  Error: %s' % (instance.rss_url, feed['bozo_exception']))
-                del feed['bozo_exception']  # have to delete to avoid pickling error in cache
+            feed = self._parse_feed(url)
             cache.set(instance.rss_url, feed, instance.cache_time)
         context.update({"instance": instance,
                         "feed": feed})
@@ -40,6 +35,20 @@ class PlanetPlugin(CMSPluginBase):
         if not ''.startswith('http') and request:
             rss_url = request.build_absolute_uri(rss_url)
         return rss_url
+
+    def _parse_feed(self, rss_url):
+        import socket
+        default_socket_timeout = socket.getdefaulttimeout()
+        try:
+            socket.setdefaulttimeout(feedparser_timeout)
+            feed = feedparser.parse(rss_url)
+            if 'bozo_exception' in feed:
+                logging.warning('Error parsing feed %s. Error: %s' % (rss_url, feed['bozo_exception']))
+                del feed['bozo_exception'] # have to delete to avoid pickling error in cache
+        finally:
+            socket.setdefaulttimeout(default_socket_timeout)
+
+        return feed
 
 
 plugin_pool.register_plugin(PlanetPlugin)


### PR DESCRIPTION
Force a low-level socket timeout when parsing feed urls.
Timeout can be configured using the settings field CMS_RSS_PLUGIN_FEEDPARSER_TIMEOUT