### PR TITLE
fix cms plugin table names

### DIFF
--- a/rssplugin/migrations/0002_auto__chg_field_rssplugin_rss_url.py
+++ b/rssplugin/migrations/0002_auto__chg_field_rssplugin_rss_url.py
@@ -4,15 +4,19 @@ from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
 
+from rssplugin.utils import rename_tables_new_to_old
+
 
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
+        rename_tables_new_to_old(db)
 
         # Changing field 'RSSPlugin.rss_url'
         db.alter_column('cmsplugin_rssplugin', 'rss_url', self.gf('django.db.models.fields.CharField')(max_length=512))
 
     def backwards(self, orm):
+        rename_tables_new_to_old(db)
 
         # Changing field 'RSSPlugin.rss_url'
         db.alter_column('cmsplugin_rssplugin', 'rss_url', self.gf('django.db.models.fields.URLField')(max_length=200))

--- a/rssplugin/migrations/0003_fix_table_names.py
+++ b/rssplugin/migrations/0003_fix_table_names.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+from south.db import db
+from south.v2 import SchemaMigration
+
+from rssplugin.utils import rename_tables_old_to_new, rename_tables_new_to_old
+
+
+class Migration(SchemaMigration):
+    def forwards(self, orm):
+        """
+        Rename tables to new scheme. The old scheme
+        will not be accepted anymore in django-cms-3.1
+        """
+        rename_tables_old_to_new(db)
+
+    def backwards(self, orm):
+        rename_tables_new_to_old(db)
+
+
+    models = {
+        'cms.cmsplugin': {
+            'Meta': {'object_name': 'CMSPlugin'},
+            'changed_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [],
+                       {'to': "orm['cms.CMSPlugin']", 'null': 'True', 'blank': 'True'}),
+            'placeholder': (
+                'django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Placeholder']", 'null': 'True'}),
+            'plugin_type': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'position': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'})
+        },
+        'cms.placeholder': {
+            'Meta': {'object_name': 'Placeholder'},
+            'default_width': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slot': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'})
+        },
+        u'rssplugin.rssplugin': {
+            'Meta': {'object_name': 'RSSPlugin', '_ormbases': ['cms.CMSPlugin']},
+            'cache_time': ('django.db.models.fields.IntegerField', [], {}),
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [],
+                               {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'count': ('django.db.models.fields.IntegerField', [], {'default': '6'}),
+            'open_in_new_window': ('django.db.models.fields.BooleanField', [], {}),
+            'rss_url': ('django.db.models.fields.CharField', [], {'max_length': '512'}),
+            'title': ('django.db.models.fields.CharField', [],
+                      {'default': "'Community News'", 'max_length': '200', 'null': 'True'})
+        }
+    }
+
+    complete_apps = ['rssplugin']

--- a/rssplugin/utils.py
+++ b/rssplugin/utils.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+default_cms_plugin_table_mapping = (
+    # (old_name, new_name),
+    ('cmsplugin_rssplugin', 'rssplugin_rssplugin'),
+)
+
+
+def rename_tables(db, table_mapping=None, reverse=False):
+    """
+    renames tables from source to destination name, if the source exists
+    and the destination does not exist yet.
+
+    taken from cmsplugin-filer:cmsplugin_filer_utils.migration (thanks to @stefanfoulis)
+    """
+    from django.db import connection
+
+    if not table_mapping:
+        table_mapping = default_cms_plugin_table_mapping
+
+    if reverse:
+        table_mapping = [(dst, src) for src, dst in table_mapping]
+    table_names = connection.introspection.table_names()
+    for source, destination in table_mapping:
+        if source in table_names and destination in table_names:
+            print(u"    WARNING: not renaming {0} to {1}, because both tables already exist.".format(source, destination))
+        elif source in table_names and destination not in table_names:
+            print(u"     - renaming {0} to {1}".format(source, destination))
+            db.rename_table(source, destination)
+
+
+def rename_tables_old_to_new(db, table_mapping=None):
+    return rename_tables(db, table_mapping, reverse=False)
+
+
+def rename_tables_new_to_old(db, table_mapping=None):
+    return rename_tables(db, table_mapping, reverse=True)


### PR DESCRIPTION
Hello.

This PR fixes the issue where the orm table names for cms plugins are still in the old format. This format is deprecated since django-cms 3.0 and will not be accepted in the upcoming release of django-cms 3.1.

The fix will make sure that the table names are according to the old format during your previous migrations (#0002) and finally rename the tables in migration #0003 to the new layout. This is done to ensure that the existing plugin migrations still work.

Please get back to me if you have any questions,

Best