### PR TITLE
Add explicit on_delete to OneToOneFields in migrations for Django 2

### DIFF
--- a/rssplugin/migrations/0001_initial.py
+++ b/rssplugin/migrations/0001_initial.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='RSSPlugin',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin')),
+                ('cmsplugin_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE)),
                 ('count', models.IntegerField(default=6)),
                 ('title', models.CharField(default=b'Community News', max_length=200, null=True, help_text="If you specified this value, it will replace feed's title")),
                 ('rss_url', models.CharField(max_length=512)),

--- a/rssplugin/migrations/0003_auto_20161210_1611.py
+++ b/rssplugin/migrations/0003_auto_20161210_1611.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='rssplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(to='cms.CMSPlugin', related_name='rssplugin_rssplugin', parent_link=True, serialize=False, primary_key=True, auto_created=True),
+            field=models.OneToOneField(to='cms.CMSPlugin', related_name='rssplugin_rssplugin', parent_link=True, serialize=False, primary_key=True, auto_created=True, on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='rssplugin',

--- a/rssplugin/migrations/0004_auto_20190523_1335.py
+++ b/rssplugin/migrations/0004_auto_20190523_1335.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='rssplugin',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
     ]


### PR DESCRIPTION
Add explicit `on_delete` arguments to `OneToOneField`s in migrations, as required in Django 2.x.